### PR TITLE
車両ごとのノッチ上限対応と非常ブレーキ処理の改善

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,9 @@
     "pyautogui",
     "pyinstaller",
     "pytest",
+    "SEIBU",
     "softprops",
+    "TOBU",
     "ZUIKI"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ Windows / Linuxでは動作を確認していません。
    ```
    uv run python main.py
    ```
+   東武・西武の車両を運転する場合は、車両に合わせて `--profile` を指定する
+   ```
+   uv run python main.py --profile tobu
+   uv run python main.py --profile seibu
+   ```
+   `--profile` を指定しない場合は `default` として動作する
+
+   | profile | 最大力行 | 最大常用ブレーキ |
+   | --- | --- | --- |
+   | `default` | P5 | B8 |
+   | `tobu` | P3 | B7 |
+   | `seibu` | P4 | B7 |
 4. この状態でJRETSの運転画面に進み、一度マスコンをNまたはEBに合わせる
    - Macで「アクセシビリティ機能を使用してこのコンピュータを制御することを求めています」と表示された場合は、アクセスを許可する
 5. 運転を開始する

--- a/main.py
+++ b/main.py
@@ -1,10 +1,17 @@
+import argparse
 import sys
-import time
+from dataclasses import dataclass
 from enum import Enum, IntEnum, auto
 
 import pygame
 import pyautogui
 from pyautogui import press
+
+
+class TrainProfile(Enum):
+    DEFAULT = auto()
+    TOBU = auto()
+    SEIBU = auto()
 
 
 class ZuikiMasconButton(IntEnum):
@@ -47,6 +54,19 @@ class Notch(IntEnum):
     EB = -9
 
 
+@dataclass(frozen=True)
+class ProfileLimit:
+    max_power: Notch
+    max_brake: Notch
+
+
+PROFILE_LIMITS: dict[TrainProfile, ProfileLimit] = {
+    TrainProfile.DEFAULT: ProfileLimit(max_power=Notch.P5, max_brake=Notch.B8),
+    TrainProfile.TOBU: ProfileLimit(max_power=Notch.P3, max_brake=Notch.B7),
+    TrainProfile.SEIBU: ProfileLimit(max_power=Notch.P4, max_brake=Notch.B7),
+}
+
+
 MAPPING_TO_KEYBOARD: dict[ZuikiMasconButton | DpadButton, str | tuple[str, ...]] = {
     # 警笛（2段目）
     ZuikiMasconButton.A: "backspace",
@@ -79,6 +99,18 @@ MAPPING_TO_KEYBOARD: dict[ZuikiMasconButton | DpadButton, str | tuple[str, ...]]
     # 勾配起動ボタン
     DpadButton.RIGHT: "g",
 }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--profile",
+        choices=("default", "tobu", "seibu"),
+        default="default",
+        help="Train profile for notch limits. default preserves the previous behavior.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser.parse_args()
 
 
 def map_to_keys(button: ZuikiMasconButton | DpadButton) -> tuple[str, ...]:
@@ -137,55 +169,80 @@ def get_notch(value: float, is_zl_button_pressed: bool) -> Notch:
         return Notch.B8
 
 
-def update_notch(current: Notch, next: Notch) -> None:
-    if Notch.N <= current < next:
-        press("z", next - current)
-    elif current <= Notch.N and next == Notch.EB:
+def project_notch(raw_notch: Notch, profile_limit: ProfileLimit) -> Notch:
+    if raw_notch >= Notch.P1:
+        return min(raw_notch, profile_limit.max_power)
+    elif Notch.EB < raw_notch <= Notch.B1:
+        return max(raw_notch, profile_limit.max_brake)
+    else:
+        return raw_notch
+
+
+def update_notch(current: Notch, next_notch: Notch, max_brake: Notch) -> None:
+    if current == next_notch:
+        return
+    elif Notch.N <= current < next_notch:
+        press("z", next_notch - current)
+    elif current <= Notch.N and next_notch == Notch.EB:
         press("/")
-    elif next < current <= Notch.N:
-        press(".", current - next)
+    elif next_notch < current <= Notch.N:
+        press(".", current - next_notch)
     elif current >= Notch.P1:
-        if next >= Notch.P1:
-            press("a", current - next)
+        if next_notch >= Notch.P1:
+            press("a", current - next_notch)
         else:
             press("s")
-            return update_notch(Notch.N, next)
+            return update_notch(Notch.N, next_notch, max_brake)
     elif current <= Notch.B1:
-        if next <= Notch.B1:
-            press(",", next - current)
+        if next_notch <= Notch.B1:
+            if current == Notch.EB:
+                presses = next_notch - max_brake + 1
+            else:
+                presses = next_notch - current
+            press(",", presses)
         else:
             press("m")
-            return update_notch(Notch.N, next)
+            return update_notch(Notch.N, next_notch, max_brake)
 
 
 def handle_axis_motion(value: float) -> None:
+    global raw_notch
     global notch
 
-    next_notch = get_notch(value, ZuikiMasconButton.ZL in pressed_buttons)
-    update_notch(notch, next_notch)
+    next_raw_notch = get_notch(value, ZuikiMasconButton.ZL in pressed_buttons)
+    next_notch = project_notch(next_raw_notch, profile_limit)
+
+    update_notch(notch, next_notch, profile_limit.max_brake)
+
+    raw_notch = next_raw_notch
     notch = next_notch
 
 
 def handle_button_down(button: ZuikiMasconButton) -> None:
+    global raw_notch
     global notch
 
     pressed_buttons.add(button)
     if button == ZuikiMasconButton.ZL:
-        if notch == Notch.B8:
-            press("/")
+        if raw_notch == Notch.B8:
+            update_notch(notch, Notch.EB, profile_limit.max_brake)
+            raw_notch = Notch.EB
             notch = Notch.EB
     else:
         key_down(button)
 
 
 def handle_button_up(button: ZuikiMasconButton) -> None:
+    global raw_notch
     global notch
 
     pressed_buttons.remove(button)
     if button == ZuikiMasconButton.ZL:
         if notch == Notch.EB:
-            press(",")
-            notch = Notch.B8
+            raw_notch = Notch.B8
+            next_notch = project_notch(raw_notch, profile_limit)
+            update_notch(notch, next_notch, profile_limit.max_brake)
+            notch = next_notch
     else:
         key_up(button)
 
@@ -206,6 +263,11 @@ def handle_hat_motion(x: int, y: int) -> None:
 
 
 if __name__ == "__main__":
+    args = parse_args()
+    profile = TrainProfile[args.profile.upper()]
+    profile_limit = PROFILE_LIMITS[profile]
+
+    raw_notch: Notch = Notch.N
     notch: Notch = Notch.N
     pressed_buttons = set[ZuikiMasconButton | DpadButton]()
 
@@ -232,7 +294,7 @@ if __name__ == "__main__":
                 case _:
                     pass
 
-            if "-v" in sys.argv[1:]:
-                print(notch.name, {button.name for button in pressed_buttons})
+            if args.verbose:
+                print(notch.name, raw_notch.name, {button.name for button in pressed_buttons})
 
         clock.tick(60)

--- a/test_main.py
+++ b/test_main.py
@@ -7,7 +7,14 @@ from pytest_mock import MockerFixture
 mock = Mock()
 sys.modules["pyautogui"] = mock
 
-from main import Notch, get_notch, update_notch
+from main import (
+    Notch,
+    PROFILE_LIMITS,
+    TrainProfile,
+    get_notch,
+    project_notch,
+    update_notch,
+)
 
 
 def test_get_notch() -> None:
@@ -29,7 +36,7 @@ def test_get_notch() -> None:
 
 
 @pytest.mark.parametrize(
-    ("current", "next", "calls"),
+    ("current", "next_notch", "calls"),
     [
         pytest.param(Notch.P2, Notch.P5, [call("z", 3)], id="P2 -> P5"),
         pytest.param(Notch.P2, Notch.P1, [call("a", 1)], id="P2 -> P1"),
@@ -46,12 +53,105 @@ def test_get_notch() -> None:
         pytest.param(Notch.B5, Notch.EB, [call("/")], id="B5 -> EB"),
         pytest.param(Notch.EB, Notch.P2, [call("m"), call("z", 2)], id="EB -> P2"),
         pytest.param(Notch.EB, Notch.N, [call("m")], id="EB -> N"),
-        pytest.param(Notch.EB, Notch.B5, [call(",", 4)], id="EB -> B5"),
     ],
 )
 def test_update_notch(
-    mocker: MockerFixture, current: Notch, next: Notch, calls: list[object]
+    mocker: MockerFixture, current: Notch, next_notch: Notch, calls: list[object]
 ) -> None:
     press_mock = mocker.patch("main.press")
-    update_notch(current, next)
+    update_notch(current, next_notch, Notch.B8)
     assert press_mock.call_args_list == calls
+
+
+@pytest.mark.parametrize(
+    "notch",
+    [Notch.P2, Notch.N, Notch.B5, Notch.EB],
+)
+def test_update_notch_does_nothing_when_notch_is_unchanged(
+    mocker: MockerFixture, notch: Notch
+) -> None:
+    press_mock = mocker.patch("main.press")
+    update_notch(notch, notch, Notch.B8)
+    press_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("profile", "current", "next_notch", "calls"),
+    [
+        pytest.param(
+            TrainProfile.DEFAULT,
+            Notch.EB,
+            Notch.B8,
+            [call(",", 1)],
+            id="default EB -> B8",
+        ),
+        pytest.param(
+            TrainProfile.DEFAULT,
+            Notch.EB,
+            Notch.B5,
+            [call(",", 4)],
+            id="default EB -> B5",
+        ),
+        pytest.param(
+            TrainProfile.TOBU,
+            Notch.EB,
+            Notch.B7,
+            [call(",", 1)],
+            id="tobu EB -> B7",
+        ),
+        pytest.param(
+            TrainProfile.TOBU,
+            Notch.EB,
+            Notch.B5,
+            [call(",", 3)],
+            id="tobu EB -> B5",
+        ),
+    ],
+)
+def test_update_notch_from_emergency_brake_uses_profile_brake_order(
+    mocker: MockerFixture,
+    profile: TrainProfile,
+    current: Notch,
+    next_notch: Notch,
+    calls: list[object],
+) -> None:
+    press_mock = mocker.patch("main.press")
+    update_notch(current, next_notch, PROFILE_LIMITS[profile].max_brake)
+    assert press_mock.call_args_list == calls
+
+
+@pytest.mark.parametrize(
+    ("profile", "raw_notch", "expected"),
+    [
+        pytest.param(
+            TrainProfile.DEFAULT,
+            Notch.P5,
+            Notch.P5,
+            id="default P5 -> P5",
+        ),
+        pytest.param(
+            TrainProfile.DEFAULT,
+            Notch.B8,
+            Notch.B8,
+            id="default B8 -> B8",
+        ),
+        pytest.param(TrainProfile.TOBU, Notch.P5, Notch.P3, id="tobu P5 -> P3"),
+        pytest.param(TrainProfile.TOBU, Notch.P4, Notch.P3, id="tobu P4 -> P3"),
+        pytest.param(TrainProfile.TOBU, Notch.P3, Notch.P3, id="tobu P3 -> P3"),
+        pytest.param(TrainProfile.TOBU, Notch.B8, Notch.B7, id="tobu B8 -> B7"),
+        pytest.param(TrainProfile.TOBU, Notch.B7, Notch.B7, id="tobu B7 -> B7"),
+        pytest.param(TrainProfile.SEIBU, Notch.P5, Notch.P4, id="seibu P5 -> P4"),
+        pytest.param(TrainProfile.SEIBU, Notch.P4, Notch.P4, id="seibu P4 -> P4"),
+        pytest.param(TrainProfile.SEIBU, Notch.B8, Notch.B7, id="seibu B8 -> B7"),
+        pytest.param(TrainProfile.SEIBU, Notch.B7, Notch.B7, id="seibu B7 -> B7"),
+    ],
+)
+def test_project_notch_applies_profile_limits(
+    profile: TrainProfile, raw_notch: Notch, expected: Notch
+) -> None:
+    assert project_notch(raw_notch, PROFILE_LIMITS[profile]) == expected
+
+
+@pytest.mark.parametrize("profile", list(TrainProfile))
+def test_project_notch_keeps_emergency_brake(profile: TrainProfile) -> None:
+    assert project_notch(Notch.EB, PROFILE_LIMITS[profile]) == Notch.EB


### PR DESCRIPTION
## 概要

車両ごとの力行・ブレーキ段数の違いに対応するため、ノッチ上限をプロファイルとして切り替えられるようにしました。あわせて、非常ブレーキ（EB）からブレーキ段へ戻る遷移を、車両ごとの最大常用ブレーキに合わせて処理するようにしています。

## 変更内容

- `TrainProfile` を追加（default / tobu / seibu）
- 車両ごとのノッチ上限を定義
  - default：P5 / B8
  - 東武：P3 / B7
  - 西武：P4 / B7
- `project_notch()` を追加し、入力された生ノッチをプロファイルごとの実効ノッチへ変換
- 生ノッチ（`raw_notch`）とJRETSへ送る実効ノッチ（`notch`）を分けて管理
- 非常ブレーキ（EB）からブレーキ段へ戻る遷移をプロファイルごとに調整
  - default は EB -> B8
  - tobu / seibu は EB -> B7
  - EBからさらに緩める場合も、各プロファイルの最大常用ブレーキを基準に押下回数を計算
- `-v/--verbose` を `argparse` で扱うように変更し、生ノッチと実効ノッチの両方を出力

## 使い方

起動時に `--profile` オプションで指定できます。

```sh
uv run python main.py --profile tobu
uv run python main.py --profile seibu
```

未指定の場合は従来通りの挙動（default）になります。

## テスト

- `project_notch()` がプロファイルごとの上限を適用すること
- EBを丸めず保持すること
- EBからブレーキ段へ戻る際の押下回数が、各プロファイルの最大常用ブレーキを基準に計算されること
- 同一ノッチへの遷移ではキー入力を送らないこと


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 列車プロファイル選択（--profile）と詳細出力（-v/--verbose）を追加
  * 選択プロファイルに基づくノッチ（動力／制動）の上限設定を導入し、入力に応じて上限内で制御

* **テスト**
  * プロファイル上限の適用やノッチ遷移の振る舞いを検証するテスト群を追加・拡充

* **ツール設定**
  * 開発環境のスペル設定を更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->