### PR TITLE
CIでuv管理Pythonを使い、macOSアプリのzip作成方法を見直す

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,14 +19,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: "3.13"
+          # Install a specific version of uv.
+          version: "0.11.12"
+      - name: Set up Python
+        run: uv python install
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
           uv sync --frozen --dev
       - name: Lint with flake8
         run: |
@@ -44,7 +45,9 @@ jobs:
         run: |
           uv run pytest
       - run: uv run pyinstaller --name "$APP_NAME" --noconsole main.py
-      - run: zip -r "$APP_NAME.app.zip" "$APP_NAME.app"
+      - run: codesign --verify --deep --strict "$APP_NAME.app"
+        working-directory: dist
+      - run: ditto -c -k --sequesterRsrc --keepParent "$APP_NAME.app" "$APP_NAME.app.zip"
         working-directory: dist
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
### 背景

CIでビルドしたmacOSアプリのtkinter UIが手元ビルドより小さく表示されていたため、CIのPython実行環境をuv-managed Pythonに寄せます。

また、uv-managed PythonでPyInstallerビルドした `.app` にはsymlinkなどmacOS bundleとして保持すべき構造が含まれるため、`zip -r` ではなくAppleの配布手順に沿って `ditto` でzipを作成します。

### 変更内容

- `actions/setup-python` と `pip install uv` をやめ、SHA pinした `astral-sh/setup-uv` を使用
- `uv` のバージョンを `0.11.12` に固定
- `uv python install` でプロジェクトのPythonを明示的にインストール
- lint、format check、type check、test、PyInstallerビルドを `uv run` 経由で実行
- PyInstallerで生成した `.app` に対して `codesign --verify --deep --strict` を実行
- `.app.zip` の作成を `zip -r` から `ditto -c -k --sequesterRsrc --keepParent` に変更

### 確認内容

- GitHub Actionsのbuildが成功することを確認
- CI artifactをダウンロードしてmacOSで開けることを確認
- CI産 `.app` のtkinter UIが小さすぎない表示になっていることを確認

### 補足

左上の3色ボタンなどウィンドウ枠まわりの見た目差は、Python/Tkの配布形態やAqua Tk側の差異が関係している可能性があるため、このPRでは追わず、CI産アプリのUIサイズとzip配布物の破損対策を対象にします。

Closes #64