### PR TITLE
重複した直接依存を削除

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ requires-python = ">=3.13,<3.14"
 dependencies = [
     "pyautogui==0.9.54",
     "pygame==2.6.1",
-    "pyobjc-core==12.1; platform_system == 'Darwin'",
-    "pyobjc-framework-cocoa==12.1; platform_system == 'Darwin'",
-    "pyobjc-framework-quartz==12.1; platform_system == 'Darwin'",
-    "rubicon-objc==0.5.4",
 ]
 
 [dependency-groups]
@@ -17,7 +13,6 @@ dev = [
     "black==26.3.1",
     "flake8==7.3.0",
     "pyinstaller==6.20.0",
-    "pyinstaller-hooks-contrib==2026.5",
     "pytest==9.0.3",
     "pytest-mock==3.15.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -454,10 +454,6 @@ source = { virtual = "." }
 dependencies = [
     { name = "pyautogui" },
     { name = "pygame" },
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
-    { name = "rubicon-objc" },
 ]
 
 [package.dev-dependencies]
@@ -466,7 +462,6 @@ dev = [
     { name = "black" },
     { name = "flake8" },
     { name = "pyinstaller" },
-    { name = "pyinstaller-hooks-contrib" },
     { name = "pytest" },
     { name = "pytest-mock" },
 ]
@@ -475,10 +470,6 @@ dev = [
 requires-dist = [
     { name = "pyautogui", specifier = "==0.9.54" },
     { name = "pygame", specifier = "==2.6.1" },
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'", specifier = "==12.1" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'", specifier = "==12.1" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'", specifier = "==12.1" },
-    { name = "rubicon-objc", specifier = "==0.5.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -487,7 +478,6 @@ dev = [
     { name = "black", specifier = "==26.3.1" },
     { name = "flake8", specifier = "==7.3.0" },
     { name = "pyinstaller", specifier = "==6.20.0" },
-    { name = "pyinstaller-hooks-contrib", specifier = "==2026.5" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-mock", specifier = "==3.15.1" },
 ]


### PR DESCRIPTION
## 概要
- `pyautogui` や `pyinstaller` から間接的に入る依存を、直接依存の宣言から削除
- `pyproject.toml` には、このプロジェクトで意図して使う実行時依存と開発依存だけを残す
- `uv.lock` のメタデータを更新

## 確認
- `uv run pytest`
- `uv run basedpyright`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * macOS/Darwin固有の実行時依存関係を削除し、インストールサイズを最適化
  * 開発依存関係を簡潔化

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiroto7/ZUIKI-MASCON-to-JRETS/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->