### PR TITLE
Show build version in status window

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -62,6 +62,11 @@ jobs:
         run: uv python install
       - name: Install dependencies
         run: uv sync --frozen --dev
+      - name: Embed build version
+        env:
+          BUILD_REF: ${{ github.ref_name }}
+          BUILD_SHA: ${{ github.sha }}
+        run: python scripts/embed_build_version.py
       - run: uv run pyinstaller --name "$APP_NAME" --noconsole main.py
       - run: codesign --verify --deep --strict "$APP_NAME.app"
         working-directory: dist

--- a/scripts/embed_build_version.py
+++ b/scripts/embed_build_version.py
@@ -1,0 +1,31 @@
+import os
+import re
+from pathlib import Path
+
+
+def build_ci_label(ref: str, sha: str) -> str:
+    return f"{ref} ({sha[:7]})"
+
+
+def update_build_label(content: str, label: str) -> str:
+    updated, count = re.subn(
+        r"^BUILD_LABEL = .*$",
+        f"BUILD_LABEL = {label!r}",
+        content,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise RuntimeError("Could not update BUILD_LABEL")
+
+    return updated
+
+
+def main() -> None:
+    path = Path("version_info.py")
+    label = build_ci_label(os.environ["BUILD_REF"], os.environ["BUILD_SHA"])
+    path.write_text(update_build_label(path.read_text(), label))
+
+
+if __name__ == "__main__":
+    main()

--- a/status_window.py
+++ b/status_window.py
@@ -11,6 +11,7 @@ from mascon_controller import (
     TrainProfile,
     effective_notch_order,
 )
+from version_info import BUILD_LABEL
 
 
 def color_for_notch(current_notch: Notch) -> str:
@@ -28,7 +29,7 @@ class StatusWindow:
         self.root = root
         self.controller = controller
         self.root.title("ZUIKI MASCON to JRETS")
-        self.root.geometry("640x300")
+        self.root.geometry("640x320")
         self.root.resizable(False, False)
         self.root.configure(bg="#f6f8fa")
         self.root.protocol("WM_DELETE_WINDOW", self.close)
@@ -118,6 +119,15 @@ class StatusWindow:
 
         self.buttons_frame = tk.Frame(root, bg="#f6f8fa", height=28)
         self.buttons_frame.pack(pady=(4, 0))
+
+        self.version_label = tk.Label(
+            root,
+            text=BUILD_LABEL,
+            font=("Helvetica", 10),
+            bg="#f6f8fa",
+            fg="#57606a",
+        )
+        self.version_label.pack(side="bottom", pady=(0, 8))
 
         self.button_labels: dict[str, tk.Label] = {}
         self.update_status()

--- a/test_embed_build_version.py
+++ b/test_embed_build_version.py
@@ -1,0 +1,25 @@
+from scripts.embed_build_version import build_ci_label, update_build_label
+
+
+def test_build_ci_label_uses_short_sha() -> None:
+    assert build_ci_label("v1.2.3", "0123456789abcdef") == "v1.2.3 (0123456)"
+
+
+def test_update_build_label_replaces_only_build_label() -> None:
+    content = "\n".join(
+        [
+            'BUILD_LABEL = "dev"',
+            "",
+            "OTHER_VALUE = 1",
+            "",
+        ]
+    )
+
+    assert update_build_label(content, "v1.2.3 (0123456)") == "\n".join(
+        [
+            "BUILD_LABEL = 'v1.2.3 (0123456)'",
+            "",
+            "OTHER_VALUE = 1",
+            "",
+        ]
+    )

--- a/version_info.py
+++ b/version_info.py
@@ -1,0 +1,1 @@
+BUILD_LABEL = "dev"


### PR DESCRIPTION
## 概要
- ステータスウィンドウ下部にビルド識別子を表示します
- macOS アプリのパッケージ前に GitHub Actions の ref と commit hash を埋め込みます
- CLI / 端末への出力は変更しません

## 補足
- Release ビルドでは tag/ref と commit hash が表示されます
- ローカル実行ではデフォルトの `dev` が表示されます
- PR の Actions artifact では、実際に checkout された `refs/pull/<PR番号>/merge` とその commit hash が表示されます

## テスト
- `uv run pytest`
- `uv run black --check .`
- `uv run basedpyright`
- `uv run flake8 . --exclude .venv --count --select=E9,F63,F7,F82 --show-source --statistics`
- `uv run flake8 . --exclude .venv --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ステータス画面にビルド情報のラベルを表示するようになりました。
  * macOS ビルドで、リリース元の情報と短縮 SHA を含むビルドラベルを自動反映するようになりました。

* **改善**
  * ステータス画面の表示領域を少し拡張し、下部にバージョン表示を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->