### PR TITLE
macOSアプリ生成スクリプトを追加

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -63,13 +63,8 @@ jobs:
           BUILD_REF: ${{ github.ref_name }}
           BUILD_SHA: ${{ github.sha }}
         run: python scripts/embed_build_version.py
-      - name: Build app icon
-        run: python scripts/build_app_icon.py
-      - run: uv run pyinstaller --name "$APP_NAME" --noconsole --icon build/app-icon.icns main.py
-      - run: codesign --verify --deep --strict "$APP_NAME.app"
-        working-directory: dist
-      - run: ditto -c -k --sequesterRsrc --keepParent "$APP_NAME.app" "$APP_NAME.app.zip"
-        working-directory: dist
+      - name: Package macOS app
+        run: ./scripts/package_macos_app.sh
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.APP_NAME }}.app

--- a/scripts/package_macos_app.sh
+++ b/scripts/package_macos_app.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="ZUIKI-MASCON-to-JRETS"
+
+uv run python scripts/build_app_icon.py
+uv run pyinstaller --noconfirm --name "$APP_NAME" --noconsole --icon build/app-icon.icns main.py
+
+cd dist
+codesign --verify --deep --strict "$APP_NAME.app"
+ditto -c -k --sequesterRsrc --keepParent "$APP_NAME.app" "$APP_NAME.app.zip"


### PR DESCRIPTION
## Summary
- macOSアプリ生成手順を `scripts/package_macos_app.sh` に集約
- CIのpackage-macos jobから同じスクリプトを呼ぶように変更
- artifact/releaseの成果物名は既存の `APP_NAME` env を維持

## Tests
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings`
- `uv run pytest`
- `./scripts/package_macos_app.sh`
- `./scripts/package_macos_app.sh` を再実行して既存distがある状態でも成功することを確認
- `git diff -- version_info.py` が空であることを確認