### PR TITLE
ZUIKI MasCon以外のコントローラー入力を無視する

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,13 +58,21 @@ def handle_pygame_events(
                 controller.register_joystick(event.dict["device_index"])
             case pygame.JOYDEVICEREMOVED:
                 controller.unregister_joystick(event.dict["instance_id"])
-            case pygame.JOYAXISMOTION:
+            case pygame.JOYAXISMOTION if controller.is_registered_joystick(
+                event.dict["instance_id"]
+            ):
                 controller.handle_axis_motion(event.dict["value"])
-            case pygame.JOYBUTTONDOWN:
+            case pygame.JOYBUTTONDOWN if controller.is_registered_joystick(
+                event.dict["instance_id"]
+            ):
                 controller.handle_button_down(ZuikiMasconButton(event.dict["button"]))
-            case pygame.JOYBUTTONUP:
+            case pygame.JOYBUTTONUP if controller.is_registered_joystick(
+                event.dict["instance_id"]
+            ):
                 controller.handle_button_up(ZuikiMasconButton(event.dict["button"]))
-            case pygame.JOYHATMOTION:
+            case pygame.JOYHATMOTION if controller.is_registered_joystick(
+                event.dict["instance_id"]
+            ):
                 controller.handle_hat_motion(*event.dict["value"])
             case pygame.QUIT:
                 controller.release_all_inputs()

--- a/mascon_controller.py
+++ b/mascon_controller.py
@@ -7,6 +7,7 @@ from pyautogui import press
 
 INPUT_POLL_HZ = 60
 PYGAME_POLL_INTERVAL_MS = 1000 // INPUT_POLL_HZ
+ZUIKI_MASCON_NAME = "ZUIKI MasCon for Nintendo Switch"
 
 
 class TrainProfile(Enum):
@@ -273,7 +274,12 @@ class MasconController:
 
     def register_joystick(self, device_index: int) -> None:
         joystick = pygame.joystick.Joystick(device_index)
+        if joystick.get_name() != ZUIKI_MASCON_NAME:
+            return
         self.joysticks[joystick.get_instance_id()] = joystick
+
+    def is_registered_joystick(self, instance_id: int) -> bool:
+        return instance_id in self.joysticks
 
     def initialize_joysticks(self) -> None:
         for device_index in range(pygame.joystick.get_count()):

--- a/test_main.py
+++ b/test_main.py
@@ -17,14 +17,30 @@ def test_handle_pygame_events_uses_controller(
 ) -> None:
     event = Mock()
     event.type = main.pygame.JOYAXISMOTION
-    event.dict = {"value": 1.0}
+    event.dict = {"instance_id": 42, "value": 1.0}
     mocker.patch("main.pygame.event.get", return_value=[event])
     controller = MasconController()
+    controller.joysticks[42] = Mock()
     handle_axis_motion_mock = mocker.patch.object(controller, "handle_axis_motion")
 
     main.handle_pygame_events(controller, Namespace(verbose=False))
 
     handle_axis_motion_mock.assert_called_once_with(1.0)
+
+
+def test_handle_pygame_events_ignores_unregistered_controller(
+    mocker: MockerFixture,
+) -> None:
+    event = Mock()
+    event.type = main.pygame.JOYBUTTONDOWN
+    event.dict = {"instance_id": 99, "button": 11}
+    mocker.patch("main.pygame.event.get", return_value=[event])
+    controller = MasconController()
+    handle_button_down_mock = mocker.patch.object(controller, "handle_button_down")
+
+    main.handle_pygame_events(controller, Namespace(verbose=False))
+
+    handle_button_down_mock.assert_not_called()
 
 
 def test_warn_if_accessibility_permission_is_missing_outputs_warning(

--- a/test_mascon_controller.py
+++ b/test_mascon_controller.py
@@ -221,6 +221,7 @@ def test_controller_register_joystick_keeps_joystick_instance(
     mocker: MockerFixture,
 ) -> None:
     joystick = Mock()
+    joystick.get_name.return_value = "ZUIKI MasCon for Nintendo Switch"
     joystick.get_instance_id.return_value = 42
     mocker.patch("mascon_controller.pygame.joystick.Joystick", return_value=joystick)
     controller = MasconController()
@@ -228,6 +229,19 @@ def test_controller_register_joystick_keeps_joystick_instance(
     controller.register_joystick(0)
 
     assert controller.joysticks == {42: joystick}
+
+
+def test_controller_register_joystick_ignores_other_controller(
+    mocker: MockerFixture,
+) -> None:
+    joystick = Mock()
+    joystick.get_name.return_value = "Xbox Series X Controller"
+    mocker.patch("mascon_controller.pygame.joystick.Joystick", return_value=joystick)
+    controller = MasconController()
+
+    controller.register_joystick(0)
+
+    assert controller.joysticks == {}
 
 
 def test_controller_initialize_joysticks_registers_connected_devices(


### PR DESCRIPTION
## 概要

ズイキマスコン接続中にXboxコントローラーを接続すると、Xbox側のボタン番号を `ZuikiMasconButton` として変換して例外が発生し、以降のpygameイベントポーリングが停止していました。

## 対応

- `ZUIKI MasCon for Nintendo Switch` だけを操作対象として登録
- 軸・ボタン・方向入力を、登録済みマスコンのinstance IDから届いたイベントに限定
- 未登録コントローラーのボタンイベントを無視する回帰テストを追加
- Xboxコントローラーが操作対象として登録されないことを確認するテストを追加

これにより、Xboxコントローラーを追加接続しても、その入力が列車操作へ混入せず、未定義のボタン番号によるイベントポーリング停止を防ぎます。

## 対象外

- ズイキマスコンPROへの対応
- SDL 3またはpygame-ceへの移行
- 従来のボタン・ノッチ・キーマッピングの変更

## 検証

- `uv run pytest`（70 passed）
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright`（0 errors, 0 warnings, 0 notes）
- Xbox Series X Controllerと従来型ズイキマスコンの同時接続状態で、操作対象としてズイキマスコンだけが登録されることを確認
