### PR TITLE
ZUIKI Mascon Proの入力を安全に処理する

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ from mascon_controller import (
 )
 from status_window import StatusWindow
 
+POWER_BRAKE_AXIS = 1
+
 
 class TkRoot(Protocol):
     def after(self, ms: int, func: Callable[[], None]) -> object: ...
@@ -49,6 +51,13 @@ def warn_if_accessibility_permission_is_missing() -> None:
         )
 
 
+def get_zuiki_mascon_button(button: int) -> ZuikiMasconButton | None:
+    try:
+        return ZuikiMasconButton(button)
+    except ValueError:
+        return None
+
+
 def handle_pygame_events(
     controller: MasconController, args: argparse.Namespace
 ) -> None:
@@ -58,12 +67,16 @@ def handle_pygame_events(
                 controller.register_joystick(event.dict["device_index"])
             case pygame.JOYDEVICEREMOVED:
                 controller.unregister_joystick(event.dict["instance_id"])
-            case pygame.JOYAXISMOTION:
+            case pygame.JOYAXISMOTION if event.dict["axis"] == POWER_BRAKE_AXIS:
                 controller.handle_axis_motion(event.dict["value"])
             case pygame.JOYBUTTONDOWN:
-                controller.handle_button_down(ZuikiMasconButton(event.dict["button"]))
+                button = get_zuiki_mascon_button(event.dict["button"])
+                if button is not None:
+                    controller.handle_button_down(button)
             case pygame.JOYBUTTONUP:
-                controller.handle_button_up(ZuikiMasconButton(event.dict["button"]))
+                button = get_zuiki_mascon_button(event.dict["button"])
+                if button is not None:
+                    controller.handle_button_up(button)
             case pygame.JOYHATMOTION:
                 controller.handle_hat_motion(*event.dict["value"])
             case pygame.QUIT:

--- a/main.py
+++ b/main.py
@@ -51,13 +51,6 @@ def warn_if_accessibility_permission_is_missing() -> None:
         )
 
 
-def get_zuiki_mascon_button(button: int) -> ZuikiMasconButton | None:
-    try:
-        return ZuikiMasconButton(button)
-    except ValueError:
-        return None
-
-
 def handle_pygame_events(
     controller: MasconController, args: argparse.Namespace
 ) -> None:
@@ -70,13 +63,9 @@ def handle_pygame_events(
             case pygame.JOYAXISMOTION if event.dict["axis"] == POWER_BRAKE_AXIS:
                 controller.handle_axis_motion(event.dict["value"])
             case pygame.JOYBUTTONDOWN:
-                button = get_zuiki_mascon_button(event.dict["button"])
-                if button is not None:
-                    controller.handle_button_down(button)
+                controller.handle_button_down(ZuikiMasconButton(event.dict["button"]))
             case pygame.JOYBUTTONUP:
-                button = get_zuiki_mascon_button(event.dict["button"])
-                if button is not None:
-                    controller.handle_button_up(button)
+                controller.handle_button_up(ZuikiMasconButton(event.dict["button"]))
             case pygame.JOYHATMOTION:
                 controller.handle_hat_motion(*event.dict["value"])
             case pygame.QUIT:

--- a/mascon_controller.py
+++ b/mascon_controller.py
@@ -33,8 +33,11 @@ class ZuikiMasconButton(IntEnum):
     ZR = 7
     MINUS = 8
     PLUS = 9
+    EB_RESET = 10
+    ATS = 11
     HOME = 12
     CAPTURE = 13
+    SQUARE = 16
 
 
 class DpadButton(Enum):
@@ -82,8 +85,10 @@ MAPPING_TO_KEYBOARD: dict[ZuikiMasconButton | DpadButton, str | tuple[str, ...]]
     ZuikiMasconButton.B: "enter",
     # EBリセットボタン
     ZuikiMasconButton.X: "e",
+    ZuikiMasconButton.EB_RESET: "e",
     # ATS確認ボタン
     ZuikiMasconButton.Y: "space",
+    ZuikiMasconButton.ATS: "space",
     # 警報持続ボタン
     ZuikiMasconButton.L: "x",
     # 抑速1
@@ -98,6 +103,8 @@ MAPPING_TO_KEYBOARD: dict[ZuikiMasconButton | DpadButton, str | tuple[str, ...]]
     ZuikiMasconButton.HOME: ("command", "g"),
     # [GeForce NOW] スクリーンショットを保存する
     ZuikiMasconButton.CAPTURE: ("command", "1"),
+    # 用途不明のためキー操作なし
+    ZuikiMasconButton.SQUARE: (),
     # レバーサ 前位置方向
     DpadButton.UP: "up",
     # レバーサ 後位置方向

--- a/mascon_controller.py
+++ b/mascon_controller.py
@@ -103,7 +103,7 @@ MAPPING_TO_KEYBOARD: dict[ZuikiMasconButton | DpadButton, str | tuple[str, ...]]
     ZuikiMasconButton.HOME: ("command", "g"),
     # [GeForce NOW] スクリーンショットを保存する
     ZuikiMasconButton.CAPTURE: ("command", "1"),
-    # 用途不明のためキー操作なし
+    # キー割り当てなし
     ZuikiMasconButton.SQUARE: (),
     # レバーサ 前位置方向
     DpadButton.UP: "up",

--- a/test_main.py
+++ b/test_main.py
@@ -44,33 +44,6 @@ def test_handle_pygame_events_ignores_non_power_brake_axis(
 
 
 @pytest.mark.parametrize(
-    "event_type", [main.pygame.JOYBUTTONDOWN, main.pygame.JOYBUTTONUP]
-)
-def test_handle_pygame_events_ignores_unknown_button_and_continues(
-    mocker: MockerFixture, event_type: int
-) -> None:
-    unknown_button_event = Mock()
-    unknown_button_event.type = event_type
-    unknown_button_event.dict = {"button": 99}
-    axis_event = Mock()
-    axis_event.type = main.pygame.JOYAXISMOTION
-    axis_event.dict = {"axis": 1, "value": 1.0}
-    mocker.patch(
-        "main.pygame.event.get", return_value=[unknown_button_event, axis_event]
-    )
-    controller = MasconController()
-    handle_button_down_mock = mocker.patch.object(controller, "handle_button_down")
-    handle_button_up_mock = mocker.patch.object(controller, "handle_button_up")
-    handle_axis_motion_mock = mocker.patch.object(controller, "handle_axis_motion")
-
-    main.handle_pygame_events(controller, Namespace(verbose=False))
-
-    handle_button_down_mock.assert_not_called()
-    handle_button_up_mock.assert_not_called()
-    handle_axis_motion_mock.assert_called_once_with(1.0)
-
-
-@pytest.mark.parametrize(
     ("button_number", "expected_button"),
     [
         (10, main.ZuikiMasconButton.EB_RESET),

--- a/test_main.py
+++ b/test_main.py
@@ -17,13 +17,57 @@ def test_handle_pygame_events_uses_controller(
 ) -> None:
     event = Mock()
     event.type = main.pygame.JOYAXISMOTION
-    event.dict = {"value": 1.0}
+    event.dict = {"axis": 1, "value": 1.0}
     mocker.patch("main.pygame.event.get", return_value=[event])
     controller = MasconController()
     handle_axis_motion_mock = mocker.patch.object(controller, "handle_axis_motion")
 
     main.handle_pygame_events(controller, Namespace(verbose=False))
 
+    handle_axis_motion_mock.assert_called_once_with(1.0)
+
+
+@pytest.mark.parametrize("axis", [0, 2, 3])
+def test_handle_pygame_events_ignores_non_power_brake_axis(
+    mocker: MockerFixture, axis: int
+) -> None:
+    event = Mock()
+    event.type = main.pygame.JOYAXISMOTION
+    event.dict = {"axis": axis, "value": 1.0}
+    mocker.patch("main.pygame.event.get", return_value=[event])
+    controller = MasconController()
+    handle_axis_motion_mock = mocker.patch.object(controller, "handle_axis_motion")
+
+    main.handle_pygame_events(controller, Namespace(verbose=False))
+
+    handle_axis_motion_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "event_type", [main.pygame.JOYBUTTONDOWN, main.pygame.JOYBUTTONUP]
+)
+@pytest.mark.parametrize("button", [10, 11, 16])
+def test_handle_pygame_events_ignores_unknown_button_and_continues(
+    mocker: MockerFixture, event_type: int, button: int
+) -> None:
+    unknown_button_event = Mock()
+    unknown_button_event.type = event_type
+    unknown_button_event.dict = {"button": button}
+    axis_event = Mock()
+    axis_event.type = main.pygame.JOYAXISMOTION
+    axis_event.dict = {"axis": 1, "value": 1.0}
+    mocker.patch(
+        "main.pygame.event.get", return_value=[unknown_button_event, axis_event]
+    )
+    controller = MasconController()
+    handle_button_down_mock = mocker.patch.object(controller, "handle_button_down")
+    handle_button_up_mock = mocker.patch.object(controller, "handle_button_up")
+    handle_axis_motion_mock = mocker.patch.object(controller, "handle_axis_motion")
+
+    main.handle_pygame_events(controller, Namespace(verbose=False))
+
+    handle_button_down_mock.assert_not_called()
+    handle_button_up_mock.assert_not_called()
     handle_axis_motion_mock.assert_called_once_with(1.0)
 
 

--- a/test_main.py
+++ b/test_main.py
@@ -46,13 +46,12 @@ def test_handle_pygame_events_ignores_non_power_brake_axis(
 @pytest.mark.parametrize(
     "event_type", [main.pygame.JOYBUTTONDOWN, main.pygame.JOYBUTTONUP]
 )
-@pytest.mark.parametrize("button", [10, 11, 16])
 def test_handle_pygame_events_ignores_unknown_button_and_continues(
-    mocker: MockerFixture, event_type: int, button: int
+    mocker: MockerFixture, event_type: int
 ) -> None:
     unknown_button_event = Mock()
     unknown_button_event.type = event_type
-    unknown_button_event.dict = {"button": button}
+    unknown_button_event.dict = {"button": 99}
     axis_event = Mock()
     axis_event.type = main.pygame.JOYAXISMOTION
     axis_event.dict = {"axis": 1, "value": 1.0}
@@ -69,6 +68,31 @@ def test_handle_pygame_events_ignores_unknown_button_and_continues(
     handle_button_down_mock.assert_not_called()
     handle_button_up_mock.assert_not_called()
     handle_axis_motion_mock.assert_called_once_with(1.0)
+
+
+@pytest.mark.parametrize(
+    ("button_number", "expected_button"),
+    [
+        (10, main.ZuikiMasconButton.EB_RESET),
+        (11, main.ZuikiMasconButton.ATS),
+        (16, main.ZuikiMasconButton.SQUARE),
+    ],
+)
+def test_handle_pygame_events_handles_pro_button(
+    mocker: MockerFixture,
+    button_number: int,
+    expected_button: main.ZuikiMasconButton,
+) -> None:
+    event = Mock()
+    event.type = main.pygame.JOYBUTTONDOWN
+    event.dict = {"button": button_number}
+    mocker.patch("main.pygame.event.get", return_value=[event])
+    controller = MasconController()
+    handle_button_down_mock = mocker.patch.object(controller, "handle_button_down")
+
+    main.handle_pygame_events(controller, Namespace(verbose=False))
+
+    handle_button_down_mock.assert_called_once_with(expected_button)
 
 
 def test_warn_if_accessibility_permission_is_missing_outputs_warning(

--- a/test_mascon_controller.py
+++ b/test_mascon_controller.py
@@ -15,9 +15,24 @@ from mascon_controller import (
     TrainProfile,
     ZuikiMasconButton,
     get_notch,
+    map_to_keys,
     project_notch,
     update_notch,
 )
+
+
+@pytest.mark.parametrize(
+    ("button", "expected_keys"),
+    [
+        (ZuikiMasconButton.EB_RESET, ("e",)),
+        (ZuikiMasconButton.ATS, ("space",)),
+        (ZuikiMasconButton.SQUARE, ()),
+    ],
+)
+def test_map_to_keys_maps_pro_buttons(
+    button: ZuikiMasconButton, expected_keys: tuple[str, ...]
+) -> None:
+    assert map_to_keys(button) == expected_keys
 
 
 def test_get_notch() -> None:


### PR DESCRIPTION
## 概要

ZUIKI Mascon Proは、マスコンハンドル以外の操作も軸入力として報告します。現行実装では軸番号を区別せず、すべての軸をノッチとして処理するため、警笛・補助操作・レバーサーで意図しないノッチ操作が発生します。また、Pro固有の物理ボタンが`ZuikiMasconButton`に定義されていませんでした。

このPRでは、Standard／Proで共通するマスコンハンドルのaxis 1だけをノッチ処理します。Pro固有ボタンは、EB Reset（button 10）を`e`、ATS（button 11）を`space`へ割り当てます。用途を確定できないSquare（button 16）は入力として認識しますが、空のキーマッピングとしてキー操作を発生させません。

## 変更しない範囲

- ZUIKI Mascon Proの警笛、パンタグラフ下降、勾配起動、レバーサーなどの固有軸は機能へ割り当てず、無視します。
- HID上でUnusedとされるbutton 14／15は考慮しません。
- 機器名、GUID、Vendor ID／Product IDによる機器判定は追加しません。
- Xboxなど他機器の入力制御はこのPRでは扱いません。
- 既存のStandard向けボタン、ハット、ノッチ変換、列車プロファイル処理は変更しません。

## 検証

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run basedpyright --warnings`
- `uv run pytest`（77件成功）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 電源ブレーキ軸からの入力のみを処理し、その他の軸入力を無視するようになりました。
  * マスコンに「EBリセット」「ATS」ボタンを追加しました。
  * EBリセットを「E」キー、ATSをスペースキーで操作できるようになりました。
  * Proコントローラーのボタン入力に対応しました。

* **改善**
  * SQUAREボタンの割り当てを見直し、キーボード操作の対象外としました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->