### PR TITLE
大量入力時の追従遅れを解消

### DIFF
--- a/mascon_controller.py
+++ b/mascon_controller.py
@@ -5,6 +5,9 @@ import pyautogui
 import pygame
 from pyautogui import press
 
+# 各キー入力後の既定100ms待機でイベント処理が滞留するのを防ぐ
+pyautogui.PAUSE = 0
+
 INPUT_POLL_HZ = 60
 PYGAME_POLL_INTERVAL_MS = 1000 // INPUT_POLL_HZ
 

--- a/test_mascon_controller.py
+++ b/test_mascon_controller.py
@@ -1,4 +1,5 @@
 import sys
+from itertools import pairwise
 from unittest.mock import Mock, call
 
 import pytest
@@ -7,6 +8,7 @@ from pytest_mock import MockerFixture
 mock = Mock()
 sys.modules["pyautogui"] = mock
 
+import mascon_controller
 from mascon_controller import (
     PROFILE_LIMITS,
     DpadButton,
@@ -33,6 +35,10 @@ def test_map_to_keys_maps_pro_buttons(
     button: ZuikiMasconButton, expected_keys: tuple[str, ...]
 ) -> None:
     assert map_to_keys(button) == expected_keys
+
+
+def test_pyautogui_pause_is_disabled() -> None:
+    assert mascon_controller.pyautogui.PAUSE == 0
 
 
 def test_get_notch() -> None:
@@ -91,6 +97,31 @@ def test_update_notch_does_nothing_when_notch_is_unchanged(
     press_mock = mocker.patch("mascon_controller.press")
     update_notch(notch, notch, Notch.B8)
     press_mock.assert_not_called()
+
+
+def test_update_notch_preserves_rapid_input_sequence(
+    mocker: MockerFixture,
+) -> None:
+    press_mock = mocker.patch("mascon_controller.press")
+    notches = (
+        Notch.EB,
+        Notch.B8,
+        Notch.B4,
+        Notch.B1,
+        Notch.N,
+        Notch.P4,
+    )
+
+    for current, next_notch in pairwise(notches):
+        update_notch(current, next_notch, Notch.B8)
+
+    assert press_mock.call_args_list == [
+        call(",", 1),
+        call(",", 4),
+        call(",", 3),
+        call("m"),
+        call("z", 4),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 概要

短時間にノッチを連続操作すると、入力処理が約0.5秒遅れて追従する状態を改善します。

## 変更内容

- PyAutoGUIが各入力処理後に追加する既定の100ms待機をゼロにしました
- `EB → B8 → B4 → B1 → N → P4` の連続入力について、生成するキーの順序と回数を固定する回帰テストを追加しました
- PyAutoGUIのフェイルセーフ、ノッチ遷移計算、入力順序、キーマッピング、60Hzポーリングは変更していません

## 背景

入力イベントはTkinterと同じスレッドで同期処理されます。PyAutoGUIの既定待機が`press()`呼び出しごとに累積し、その間に後続イベントが滞留していました。対象の連続入力を無出力バックエンドで計測すると、変更前は約0.51秒、変更後は約0.00002秒でした。

## 検証

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright --warnings`
- `uv run pytest`（79 passed）

実機でJRETSの最終ノッチがP4へ遅延なく追従することは、別途確認が必要です。